### PR TITLE
Namespace fix in default config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -88,7 +88,7 @@ class Configuration implements ConfigurationInterface
                         ->arrayNode('provider')
                             ->addDefaultsIfNotSet()
                             ->children()
-                                ->scalarNode('profile_provider')->defaultValue('CCDNForum\ForumBundle\Component\Provider\SimpleProfileProvider')->end()
+                                ->scalarNode('profile_provider')->defaultValue('CCDNForum\ForumBundle\Component\Provider\Profile\SimpleProfileProvider')->end()
                             ->end()
                         ->end()
                     ->end()


### PR DESCRIPTION
Fixed namespace:

`CCDNForum\ForumBundle\Component\Provider\SimpleProfileProvider`

does not exist, however

`CCDNForum\ForumBundle\Component\Provider\Profile\SimpleProfileProvider`

does.
