### PR TITLE
Fixed typo in category edit template, triple closing curly brace

### DIFF
--- a/Resources/views/Admin/Category/edit.html.twig
+++ b/Resources/views/Admin/Category/edit.html.twig
@@ -25,7 +25,7 @@
 				<div class="form-group">
 					<div class="col-lg-offset-2 col-lg-10">
 						<h4>
-							{{- 'title.admin.manage-categories.edit' |trans({'%category_name%': category.name}, 'CCDNForumForumBundle') -}}}
+							{{- 'title.admin.manage-categories.edit' |trans({'%category_name%': category.name}, 'CCDNForumForumBundle') -}}
 						</h4>
 					</div>
 				</div>


### PR DESCRIPTION
Typo in template fixed, it should be only }} not }}}